### PR TITLE
Add options to netem only if they are used

### DIFF
--- a/netimpair.py
+++ b/netimpair.py
@@ -174,11 +174,24 @@ class NetemInstance(object):
             'tc qdisc add dev {0} parent 1:3 handle 30: netem'.format(
                 self.nic))
         while toggle:
-            impair_cmd = 'tc qdisc change dev {0} parent 1:3 handle 30: ' \
-                'netem loss {1}% {2}% duplicate {3}% delay {4}ms {5}ms {6}% ' \
-                'reorder {7}% {8}%'.format(
-                    self.nic, loss_ratio, loss_corr, dup_ratio, delay, jitter,
-                    delay_jitter_corr, reorder_ratio, reorder_corr)
+            impair_cmd = 'tc qdisc change dev {0} parent 1:3 handle 30: netem '.format(self.nic)
+            if loss_ratio > 0:
+                impair_cmd += 'loss {0}% '.format(loss_ratio)
+                if loss_corr > 0:
+                    impair_cmd += '{0}% '.format(loss_corr)
+            if dup_ratio > 0:
+                impair_cmd += 'duplicate {0}% '.format(dup_ratio)
+            if delay > 0:
+                impair_cmd += 'delay {0}ms '.format(delay)
+                if jitter > 0:
+                    impair_cmd += '{0}ms '.format(jitter)
+                    if delay_jitter_corr > 0:
+                        impair_cmd += '{0}% '.format(delay_jitter_corr)
+            if reorder_ratio > 0:
+                impair_cmd += 'reorder {0}% '.format(reorder_ratio, reorder_corr)
+                if reorder_corr > 0:
+                    impair_cmd += '{0}% '.format(reorder_corr)
+
             print('Setting network impairment:')
             print(impair_cmd)
             # Set network impairment


### PR DESCRIPTION
It seems that `netem` doesn't like arguments whose value is 0.

When running in an Ubuntu 18.04.6 LTS installation with _linux-modules-extra_ I continously got the following error:
```
$ sudo ./netimpair.py -n ens160 netem --jitter 200

... (some lines left out for brevity) ...

Setting network impairment:
tc qdisc change dev ens160 parent 1:3 handle 30: netem loss 0% 0% duplicate 0% delay 0ms 200ms 0% reorder 0% 0%
Illegal "loss percent"
Traceback (most recent call last):
  File "./ni.py", line 295, in main
    args.toggle)
  File "./ni.py", line 185, in netem
    self._check_call(impair_cmd)
  File "./ni.py", line 58, in _check_call
    subprocess.check_call(shlex.split(command))
  File "/usr/lib/python3.6/subprocess.py", line 311, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['tc', 'qdisc', 'change', 'dev', 'ens160', 'parent', '1:3', 'handle', '30:', 'netem', 'loss', '0%', '0%', 'duplicate', '0%', 'delay', '0ms', '200ms', '0%', 'reorder', '0%', '0%']' returned non-zero exit status 1.
Network impairment teardown complete.
```

I tracked the problem down and discovered that not passing the zero-values made it work. Therefore I modified the code in order to concatenate them to the `tc` command only when present (bigger than 0).

I was not able to test this out in other environments, but it don't think that removing superfluous arguments may cause problems. In any case it would be nice to cross-check if `netem` admits negative values for its arguments, it doesn't seem so but if possible will cause problems the way I programmed the argument existence verification.